### PR TITLE
refactor PaddlePaddle Backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(PADDLE_INCLUDE_PATHS "${PADDLE_INFERENCE_DIR}/include"
   CACHE PATH "Paths to Paddle Inference includes. Multiple paths may be specified by sparating them with a semicolon.")
 set(PADDLE_LIB_PATHS "${PADDLE_INFERENCE_DIR}/lib"
   CACHE PATH "Paths to Paddle Inference libraries. Multiple paths may be specified by sparating them with a semicolon.")
-set(PADDLE_LIB_NAME "paddle_inference")
+set(PADDLE_LIB_NAME "paddle_inference_c")
 
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")

--- a/src/paddle.cc
+++ b/src/paddle.cc
@@ -29,441 +29,59 @@
 #include <numeric>
 
 #include "paddle_backend_utils.h"
-#include "paddle_inference_api.h"
+#include "pd_inference_api.h"
 #include "triton/backend/backend_common.h"
 #include "triton/backend/backend_input_collector.h"
+#include "triton/backend/backend_memory.h"
 #include "triton/backend/backend_model.h"
 #include "triton/backend/backend_model_instance.h"
 #include "triton/backend/backend_output_responder.h"
 
-struct TRITONPADDLE_Tensor;
-
-// Paddle Predictor Wrapper
-struct TRITONPADDLE_Model;
-
-class ModelImpl {
- public:
-  ModelImpl(
-      const char* model_path, const char* param_path,
-      TRITONPADDLE_Config* config, const int32_t device_id, cudaStream_t stream);
-  ~ModelImpl() = default;
-  void CollectShapeRun(paddle_infer::Predictor* predictor,
-                       const std::map<std::string, std::vector<int>>& shape);
-  void CollectTensorRtShapeRange(const char* model_path, const char* param_path,
-                                 TRITONPADDLE_Config* config,
-                                 const int32_t device_id);
-  TRITONPADDLE_Error* Run();
-
-  TRITONPADDLE_Error* GetInputPtr(
-      const char* name, const TRITONPADDLE_DataType dtype,
-      const TRITONPADDLE_Shape& shape, char** ptr);
-
-  TRITONPADDLE_Error* GetOutputMetadata(
-      const char* name, TRITONPADDLE_DataType* dtype, TRITONPADDLE_Shape* shape,
-      char** ptr);
-
-  TRITONPADDLE_Error* ZeroCopyRun();
-
- private:
-  // TODO(wilber): unique_ptr?
-  std::unique_ptr<paddle_infer::Config> analysis_config_;
-  std::shared_ptr<paddle_infer::Predictor> predictor_;
-  paddle_infer::PlaceType place_type_;
-  std::string shape_range_info_;
-};
-
-void ModelImpl::CollectShapeRun(paddle_infer::Predictor* predictor,
-                                const std::map<std::string, std::vector<int>>& shape) {
-  auto input_names = predictor->GetInputNames();
-  auto input_type = predictor->GetInputTypes();
-  for(auto name : input_names) {
-    if(shape.find(name) == shape.end() or
-       input_type.find(name) == input_type.end()) {
-      TRITONPADDLE_Error* error = TRITONPADDLE_ErrorNew(
-          std::string("Paddle Input name [") + std::string(name) +
-          std::string("] is not one of the trt dynamic_shape"));
-      THROW_IF_TRITONPADDLE_ERROR(error);
-    }
-
-    auto tensor = predictor->GetInputHandle(name);
-    auto shape_value = shape.at(name);
-    int shape_num = std::accumulate(shape_value.begin(), shape_value.end(), 1,
-                                    std::multiplies<int>());
-    tensor->Reshape(shape_value);
-    auto dtype = input_type[name];
-    switch (dtype) {
-      case paddle_infer::DataType::FLOAT32: {
-        std::vector<float> input_data(shape_num, 1.0);
-        tensor->CopyFromCpu(input_data.data());
-        break;
-      }
-      case paddle_infer::DataType::INT32: {
-        std::vector<int> input_data(shape_num, 1);
-        tensor->CopyFromCpu(input_data.data());
-        break;
-      }
-      case paddle_infer::DataType::INT64: {
-        std::vector<int64_t> input_data(shape_num, 1);
-        tensor->CopyFromCpu(input_data.data());
-        break;
-      }
-      case paddle_infer::DataType::FLOAT16: {
-        std::vector<phi::dtype::float16> input_data(shape_num, (phi::dtype::float16)1.0);
-        tensor->CopyFromCpu(input_data.data());
-        break;
-      }
-      default: {
-        TRITONPADDLE_Error* error = TRITONPADDLE_ErrorNew(std::string(
-            "input data Paddle backend only supports FP32/INT32/INT64 currently"));
-        THROW_IF_TRITONPADDLE_ERROR(error);
-        break;
-      }
-    }
-  }
-  predictor->Run();
-}
-
-void ModelImpl::CollectTensorRtShapeRange(const char* model_path, const char* param_path,
-                                          TRITONPADDLE_Config* config,
-                                          const int32_t device_id) {
-  paddle_infer::Config analysis_config;
-  if (param_path == nullptr) {
-    analysis_config.SetModel(model_path, "");
-  } else {
-    analysis_config.SetModel(model_path, param_path);
-  }
-  // analysis_config.EnableUseGpu(100, device_id);
-  analysis_config.CollectShapeRangeInfo(shape_range_info_);
-  auto predictor = paddle_infer::CreatePredictor(analysis_config);
-  CollectShapeRun(predictor.get(), config->dynamic_min_shape_);
-  CollectShapeRun(predictor.get(), config->dynamic_max_shape_);
-  CollectShapeRun(predictor.get(), config->dynamic_opt_shape_);
-}
-
-ModelImpl::ModelImpl(
-    const char* model_path, const char* param_path, TRITONPADDLE_Config* config,
-    const int32_t device_id, cudaStream_t stream)
-{
-  analysis_config_.reset(new paddle_infer::Config());
-
-  if (param_path == nullptr) {
-    analysis_config_->SetModel(model_path, "");
-  } else {
-    analysis_config_->SetModel(model_path, param_path);
-  }
-
-  // default settings
-  analysis_config_->SwitchSpecifyInputNames(true);
-  analysis_config_->SwitchIrOptim(true);
-  analysis_config_->EnableMemoryOptim();
-  analysis_config_->SwitchUseFeedFetchOps(false);
-
-  if (config->use_cpu_) {
-    place_type_ = paddle_infer::PlaceType::kCPU;
-    analysis_config_->SetCpuMathLibraryNumThreads(config->cpu_math_library_num_threads_);
-    if(config->use_ort_) {
-      analysis_config_->EnableONNXRuntime();
-      analysis_config_->EnableORTOptimization();
-    } else if(config->use_mkldnn_) {
-      analysis_config_->EnableMKLDNN();
-      analysis_config_->SetMkldnnCacheCapacity(config->mkldnn_capacity_);
-      // Release/2.3 don't support mkldnn_int8
-      // if(config->use_mkldnn_int8_)
-      //   analysis_config_->EnableMkldnnInt8();
-    }
-  } else {
-    place_type_ = paddle_infer::PlaceType::kGPU;
-    analysis_config_->EnableUseGpu(100, device_id);
-    analysis_config_->SetExecStream((void*)stream);
-
-    paddle::AnalysisConfig::Precision compute_precision;
-    compute_precision = paddle::AnalysisConfig::Precision::kFloat32;
-    if (config->precision_ == TRITONPADDLE_MODE_FP32) {
-      compute_precision = paddle::AnalysisConfig::Precision::kFloat32;
-    } else if (config->precision_ == TRITONPADDLE_MODE_FP16) {
-      compute_precision = paddle::AnalysisConfig::Precision::kHalf;
-    } else if (config->precision_ == TRITONPADDLE_MODE_INT8) {
-      compute_precision = paddle::AnalysisConfig::Precision::kInt8;
-    } else {
-      TRITONPADDLE_Error* error = TRITONPADDLE_ErrorNew(
-          "unknown precision type when setting tensorrt compute precision.");
-      THROW_IF_TRITONPADDLE_ERROR(error);
-    }
-
-    if (config->use_trt_) {
-      analysis_config_->EnableTensorRtEngine(
-        config->workspace_size_, config->max_batch_size_,
-        config->min_graph_size_, compute_precision, false, false);
-      if (config->enable_tensorrt_oss_) {
-        analysis_config_->EnableVarseqlen();
-      }
-      if (config->is_dynamic_) {
-        shape_range_info_ = triton::backend::JoinPath({config->model_dir_, "shape_range_info.pbtxt"});
-        if (!config->disenable_trt_tune_) {
-          CollectTensorRtShapeRange(model_path, param_path, config, device_id);
-        }
-        analysis_config_->EnableTunedTensorRtDynamicShape(shape_range_info_);
-      }
-    }
-  }
-  predictor_ = std::move(paddle_infer::CreatePredictor(*analysis_config_.get()));
-}
-
-TRITONPADDLE_Error*
-ModelImpl::Run()
-{
-  predictor_->Run();
-
-  // TODO: paddle predictor stream controll
-  if(analysis_config_->use_gpu())
-    cudaDeviceSynchronize();
-  return nullptr;
-}
-
-TRITONPADDLE_Error*
-ModelImpl::GetInputPtr(
-    const char* name, const TRITONPADDLE_DataType dtype,
-    const TRITONPADDLE_Shape& shape, char** ptr)
-{
-  auto input_names = predictor_->GetInputNames();
-
-  // check whether the given name is in predictor_ input names
-  if (std::find(input_names.begin(), input_names.end(), std::string(name)) ==
-      input_names.end()) {
-    return TRITONPADDLE_ErrorNew(
-        std::string("Input name [") + std::string(name) +
-        std::string("] is not one of the Paddle predictor input"));
-  }
-
-  auto tensor = predictor_->GetInputHandle(name);
-  tensor->Reshape(shape.CompatibleShape());
-  switch (dtype) {
-    case TRITONPADDLE_TYPE_FP32:
-      *ptr = reinterpret_cast<char*>(
-          tensor->mutable_data<float>(place_type_));
-      break;
-    case TRITONPADDLE_TYPE_INT32:
-      *ptr = reinterpret_cast<char*>(
-          tensor->mutable_data<int32_t>(place_type_));
-      break;
-    case TRITONPADDLE_TYPE_INT64:
-      *ptr = reinterpret_cast<char*>(
-          tensor->mutable_data<int64_t>(place_type_));
-      break;
-    case TRITONPADDLE_TYPE_FP16:
-      *ptr = reinterpret_cast<char*>(
-          tensor->mutable_data<phi::dtype::float16>(place_type_));
-      break;
-    default:
-      return TRITONPADDLE_ErrorNew(std::string(
-          "Paddle backend only supports FP32/INT32/INT64 currently"));
-  }
-
-  return nullptr;
-}
-
-TRITONPADDLE_Error*
-ModelImpl::GetOutputMetadata(
-    const char* name, TRITONPADDLE_DataType* dtype, TRITONPADDLE_Shape* shape,
-    char** ptr)
-{
-  auto output_names = predictor_->GetOutputNames();
-
-  // check whether the given name is in predictor_ output names
-  if (std::find(output_names.begin(), output_names.end(), std::string(name)) ==
-      output_names.end()) {
-    return TRITONPADDLE_ErrorNew(
-        std::string("Output name [") + std::string(name) +
-        std::string("] is not one of the Paddle predictor input"));
-  }
-
-  auto tensor = predictor_->GetOutputHandle(name);
-  auto tensor_type = tensor->type();
-  auto tensor_shape = tensor->shape();
-
-  *dtype = ConvertDataType(tensor_type);
-  *shape = TRITONPADDLE_Shape(tensor_shape);
-
-  switch (*dtype) {
-    case TRITONPADDLE_TYPE_FP32:
-      *ptr = reinterpret_cast<char*>(
-          tensor->mutable_data<float>(place_type_));
-      break;
-    case TRITONPADDLE_TYPE_INT64:
-      *ptr = reinterpret_cast<char*>(
-          tensor->mutable_data<int64_t>(place_type_));
-      break;
-    case TRITONPADDLE_TYPE_INT32:
-      *ptr = reinterpret_cast<char*>(
-          tensor->mutable_data<int32_t>(place_type_));
-      break;
-    case TRITONPADDLE_TYPE_FP16:
-      *ptr = reinterpret_cast<char*>(
-          tensor->mutable_data<phi::dtype::float16>(place_type_));
-      break;
-    /*
-    case TRITONPADDLE_TYPE_INT8:
-      *ptr = reinterpret_cast<char*>(
-          tensor->mutable_data<int8_t>(place_type_));
-      break;
-    case TRITONPADDLE_TYPE_UINT8:
-      *ptr = reinterpret_cast<char*>(
-          tensor->mutable_data<uint8_t>(place_type_));
-      break;
-    */
-    default:
-      return TRITONPADDLE_ErrorNew(std::string(
-          "Paddle backend currently only support FP32/INT32/INT64"));
-  }
-
-  return nullptr;
-}
-
-TRITONSERVER_Error*
-TRITONPADDLE_ModelCreate(
-    TRITONPADDLE_Model** model, const char* model_path, const char* param_path,
-    TRITONPADDLE_Config* config, const int32_t device_id, cudaStream_t stream)
-{
-  try {
-    ModelImpl* model_impl =
-        new ModelImpl(model_path, param_path, config, device_id, stream);
-    *model = reinterpret_cast<TRITONPADDLE_Model*>(model_impl);
-  }
-  catch (const TRITONPADDLE_Exception& ex) {
-    RETURN_IF_TRITONPADDLE_ERROR(ex.err_);
-  }
-  return nullptr;
-}
-
-void
-TRITONPADDLE_ModelDelete(TRITONPADDLE_Model* model)
-{
-  if (model != nullptr) {
-    ModelImpl* mi = reinterpret_cast<ModelImpl*>(model);
-    delete mi;
-  }
-}
-
-TRITONPADDLE_Error*
-TRITONPADDLE_ModelRun(TRITONPADDLE_Model* model)
-{
-  ModelImpl* m = reinterpret_cast<ModelImpl*>(model);
-  return m->Run();
-}
-
-class TensorImpl {
- public:
-  TensorImpl(
-      const char* name, TRITONPADDLE_DataType dtype,
-      const TRITONPADDLE_Shape& shape, char* data_ptr);
-  ~TensorImpl() = default;
-
-  const std::string& Name() const { return name_; }
-  TRITONPADDLE_DataType DataType() const { return dtype_; }
-  TRITONPADDLE_Shape Shape() const { return shape_; }
-
-  char* Base() const { return base_; }
-  size_t ByteSize() const { return byte_size_; }
-
- private:
-  const std::string name_;
-  const TRITONPADDLE_DataType dtype_;
-  const TRITONPADDLE_Shape shape_;
-
-  char* base_;
-  size_t byte_size_;
-};
-
-TensorImpl::TensorImpl(
-    const char* name, TRITONPADDLE_DataType dtype,
-    const TRITONPADDLE_Shape& shape, char* data_ptr)
-    : name_(name), dtype_(dtype), shape_(shape), base_(data_ptr)
-{
-  byte_size_ = shape.NumElements() * TRITONPADDLE_DataTypeByteSize(dtype);
-}
-
-TRITONPADDLE_Tensor*
-TRITONPADDLE_TensorNew(
-    TRITONPADDLE_Model* model, const char* name, TRITONPADDLE_DataType dtype,
-    const TRITONPADDLE_Shape& shape)
-{
-  char* data_ptr;
-  ModelImpl* m = reinterpret_cast<ModelImpl*>(model);
-  auto err = m->GetInputPtr(name, dtype, shape, &data_ptr);
-  if (err != nullptr) {
-    return nullptr;
-  }
-
-  TensorImpl* tensor = new TensorImpl(name, dtype, shape, data_ptr);
-  return reinterpret_cast<TRITONPADDLE_Tensor*>(tensor);
-}
-
-TRITONPADDLE_Tensor*
-TRITONPADDLE_TensorNew(TRITONPADDLE_Model* model, const char* name)
-{
-  char* data_ptr;
-  TRITONPADDLE_DataType dtype;
-  TRITONPADDLE_Shape shape;
-
-  ModelImpl* m = reinterpret_cast<ModelImpl*>(model);
-  auto err = m->GetOutputMetadata(name, &dtype, &shape, &data_ptr);
-  if (err != nullptr) {
-    return nullptr;
-  }
-
-  TensorImpl* tensor = new TensorImpl(name, dtype, shape, data_ptr);
-  return reinterpret_cast<TRITONPADDLE_Tensor*>(tensor);
-}
-
-char*
-TRITONPADDLE_TensorData(TRITONPADDLE_Tensor* tensor)
-{
-  TensorImpl* t = reinterpret_cast<TensorImpl*>(tensor);
-  return t->Base();
-}
-
-size_t
-TRITONPADDLE_TensorDataByteSize(TRITONPADDLE_Tensor* tensor)
-{
-  TensorImpl* t = reinterpret_cast<TensorImpl*>(tensor);
-  return t->ByteSize();
-}
-
-TRITONPADDLE_DataType
-TRITONPADDLE_TensorDataType(TRITONPADDLE_Tensor* tensor)
-{
-  TensorImpl* t = reinterpret_cast<TensorImpl*>(tensor);
-  return t->DataType();
-}
-
-TRITONPADDLE_Shape
-TRITONPADDLE_TensorShape(TRITONPADDLE_Tensor* tensor)
-{
-  TensorImpl* t = reinterpret_cast<TensorImpl*>(tensor);
-  return t->Shape();
-}
-
 namespace triton { namespace backend { namespace paddle {
 
-using TRITONPADDLEModelHandle = std::shared_ptr<TRITONPADDLE_Model>;
+// BackendConfiguration
+struct BackendConfiguration {
+  BackendConfiguration() : default_max_batch_size_(0) {}
+  int default_max_batch_size_;
+};
 
 class ModelState : public BackendModel {
  public:
   static TRITONSERVER_Error* Create(
       TRITONBACKEND_Model* triton_model, ModelState** state);
   virtual ~ModelState() = default;
-  TRITONPADDLE_Config* PaddleConfig() { return &config_; }
+
+  TRITONSERVER_Error* PrintModelConfig();
+
+  // Load an Paddle model using 'artifact_name' as the name for the Paddle
+  // file/directory. If 'instance_group_kind' is not
+  // TRITONSERVER_INSTANCEGROUPKIND_AUTO then use it and
+  // 'instance_group_device_id' to initialize the appropriate
+  // execution providers. Return in 'model_path' the full path to the
+  // paddle file.
+  TRITONSERVER_Error* LoadModel(
+      const std::string& artifact_name,
+      const TRITONSERVER_InstanceGroupKind instance_group_kind,
+      const int32_t instance_group_device_id,
+      std::string* model_path, std::string* params_path,
+      cudaStream_t stream, PD_PlaceType* pd_plcace_type,
+      PD_Predictor** predictor);
 
  private:
   ModelState(TRITONBACKEND_Model* triton_model);
-
-  // Auto-complete the model configuration
   TRITONSERVER_Error* AutoCompleteConfig();
+  TRITONSERVER_Error* AutoCompleteMaxBatch(
+      const PaddleTensorInfoMap& input_tensor_infos,
+      const PaddleTensorInfoMap& output_tensor_infos);
+  TRITONSERVER_Error* AutoCompleteIO(
+      const char* key, const PaddleTensorInfoMap& io_infos);
+  TRITONSERVER_Error* CollectTensorRtShapeRange(std::string* model_path, std::string* param_path,
+                                 const char* range_info_path, int32_t device_id);
+  TRITONSERVER_Error* CollectShapeRun(PD_Predictor* predictor,
+                                 const std::unordered_map<std::string, std::vector<int>>& shape);  
 
-  // Validate that model configuration is supported by this backend
-  TRITONSERVER_Error* ValidateModelConfig();
-
-  TRITONPADDLE_Config config_;
+  std::unique_ptr<PD_Config, PDConfigDeleter> pd_config_;
+  PaddleTRTConfig pd_trt_config_;
 };
 
 TRITONSERVER_Error*
@@ -485,25 +103,18 @@ ModelState::Create(TRITONBACKEND_Model* triton_model, ModelState** state)
       triton_model, &auto_complete_config));
   if (auto_complete_config) {
     RETURN_IF_ERROR((*state)->AutoCompleteConfig());
-
-    triton::common::TritonJson::WriteBuffer json_buffer;
-    (*state)->ModelConfig().Write(&json_buffer);
-
-    TRITONSERVER_Message* message;
-    RETURN_IF_ERROR(TRITONSERVER_MessageNewFromSerializedJson(
-        &message, json_buffer.Base(), json_buffer.Size()));
-    RETURN_IF_ERROR(TRITONBACKEND_ModelSetConfig(
-        triton_model, 1 /* config_version */, message));
+    RETURN_IF_ERROR((*state)->SetModelConfig());
   }
-
-  RETURN_IF_ERROR((*state)->ValidateModelConfig());
 
   return nullptr;  // success
 }
 
 ModelState::ModelState(TRITONBACKEND_Model* triton_model)
-    : BackendModel(triton_model)
-{
+    : BackendModel(triton_model) {
+  // Create pd_config that will be cloned and used for each
+  // instance when creating that instance's predictor.
+  PD_Config* pd_config = PD_ConfigCreate();
+  pd_config_.reset(pd_config);
 
   triton::common::TritonJson::Value optimization;
   if (not ModelConfig().Find("optimization", &optimization)) {
@@ -525,9 +136,10 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
         std::string name;
         THROW_IF_BACKEND_MODEL_ERROR(ea.MemberAsString("name", &name));
         if (name == "mkldnn") {
-          config_.use_mkldnn_ = true;
+          PD_ConfigEnableMKLDNN(pd_config);
         } else if (name == "ort") {
-          config_.use_ort_ = true;
+          PD_ConfigEnableONNXRuntime(pd_config);
+          PD_ConfigEnableORTOptimization(pd_config);
         } else if (name != "") {
           TRITONSERVER_Error* error = TRITONSERVER_ErrorNew(
               TRITONSERVER_ERROR_INVALID_ARG,
@@ -544,20 +156,37 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
           for (const auto& param_key : param_keys) {
             std::string value_string;
             if (param_key == "cpu_threads") {
+              int cpu_threads = 1;
               THROW_IF_BACKEND_MODEL_ERROR(
                   params.MemberAsString(param_key.c_str(), &value_string));
               THROW_IF_BACKEND_MODEL_ERROR(
-                  ParseIntValue(value_string, &config_.cpu_math_library_num_threads_));
+                  ParseIntValue(value_string, &cpu_threads));
+              PD_ConfigSetCpuMathLibraryNumThreads(pd_config, cpu_threads);
             } else if (param_key == "capacity") {
+              int mkldnn_capacity = 1;
               THROW_IF_BACKEND_MODEL_ERROR(
                   params.MemberAsString(param_key.c_str(), &value_string));
               THROW_IF_BACKEND_MODEL_ERROR(
-                  ParseIntValue(value_string, &config_.mkldnn_capacity_));
+                  ParseIntValue(value_string, &mkldnn_capacity));
+              PD_ConfigSetMkldnnCacheCapacity(pd_config, mkldnn_capacity);
+            } else if (param_key == "use_fp16") {
+              bool use_float16 = false;
+              THROW_IF_BACKEND_MODEL_ERROR(
+                  params.MemberAsString(param_key.c_str(), &value_string));
+              THROW_IF_BACKEND_MODEL_ERROR(
+                  ParseBoolValue(value_string, &use_float16));
+              if (use_float16) {
+                PD_ConfigEnableMkldnnBfloat16(pd_config);
+              }
             } else if (param_key == "use_int8") {
+              bool use_int8 = false;
               THROW_IF_BACKEND_MODEL_ERROR(
                   params.MemberAsString(param_key.c_str(), &value_string));
               THROW_IF_BACKEND_MODEL_ERROR(
-                  ParseBoolValue(value_string, &config_.use_mkldnn_int8_));
+                  ParseBoolValue(value_string, &use_int8));
+              if (use_int8) {
+                PD_ConfigEnableMkldnnInt8(pd_config);
+              }
             }
           }
         }
@@ -569,6 +198,14 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
   {
     triton::common::TritonJson::Value gpu_eas;
     if (eas.Find("gpu_execution_accelerator", &gpu_eas)) {
+      size_t names_num = 0;
+      char** input_tensor_names = NULL;
+      size_t* shapes_num = NULL;
+      int32_t** min_shapes = NULL;
+      int32_t** max_shapes = NULL;
+      int32_t** opt_shapes = NULL;
+      PD_Bool disable_trt_plugin_fp16 = 0;
+
       for (size_t idx = 0; idx < gpu_eas.ArraySize(); idx++) {
         triton::common::TritonJson::Value ea;
         THROW_IF_BACKEND_MODEL_ERROR(gpu_eas.IndexAsObject(idx, &ea));
@@ -576,7 +213,12 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
         THROW_IF_BACKEND_MODEL_ERROR(ea.MemberAsString("name", &name));
 
         if (name == "tensorrt") {
-          config_.use_trt_ = true;
+          int64_t workspace_size = 1 << 30;
+          int32_t max_batch_size = 1;
+          int32_t min_subgraph_size = 3;
+          PD_PrecisionType precision = PD_PRECISION_FLOAT32;
+          PD_Bool use_static = 0;
+          PD_Bool use_calib_mode = 1;
           triton::common::TritonJson::Value params;
           if (ea.Find("parameters", &params)) {
             std::vector<std::string> param_keys;
@@ -590,17 +232,17 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
                     value_string.begin(), value_string.end(), value_string.begin(),
                     ::tolower);
                 if (value_string == "trt_fp32") {
-                  config_.precision_ = TRITONPADDLE_MODE_FP32;
+                  precision = PD_PRECISION_FLOAT32;
                 } else if (value_string == "trt_fp16") {
-                  config_.precision_ = TRITONPADDLE_MODE_FP16;
+                  precision = PD_PRECISION_HALF;
                 } else if (value_string == "trt_int8") {
-                  config_.precision_ = TRITONPADDLE_MODE_INT8;
+                  precision = PD_PRECISION_INT8;
                 } else {
                   TRITONSERVER_Error* error = TRITONSERVER_ErrorNew(
                       TRITONSERVER_ERROR_INVALID_ARG,
                       std::string(
                           "unknown precision type '" + value_string +
-                          "' is provided. Available choices are [fluid, trt_fp32, "
+                          "' is provided. Available choices are [trt_fp32, "
                           "trt_fp16, trt_int8]")
                           .c_str());
                   THROW_IF_BACKEND_MODEL_ERROR(error);
@@ -609,33 +251,45 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
                 THROW_IF_BACKEND_MODEL_ERROR(
                     params.MemberAsString(param_key.c_str(), &value_string));
                 THROW_IF_BACKEND_MODEL_ERROR(
-                    ParseLongLongValue(value_string, &config_.min_graph_size_));
+                    ParseIntValue(value_string, &min_subgraph_size));
               } else if (param_key == "workspace_size") {
                 THROW_IF_BACKEND_MODEL_ERROR(
                     params.MemberAsString(param_key.c_str(), &value_string));
                 THROW_IF_BACKEND_MODEL_ERROR(
-                    ParseLongLongValue(value_string, &config_.workspace_size_));
+                    ParseLongLongValue(value_string, &workspace_size));
               } else if (param_key == "max_batch_size") {
                 THROW_IF_BACKEND_MODEL_ERROR(
                     params.MemberAsString(param_key.c_str(), &value_string));
                 THROW_IF_BACKEND_MODEL_ERROR(
-                    ParseLongLongValue(value_string, &config_.max_batch_size_));
+                    ParseIntValue(value_string, &max_batch_size));
               } else if (param_key == "enable_tensorrt_oss") {
+                bool tensorrt_oss_enabled = false;
                 THROW_IF_BACKEND_MODEL_ERROR(
                     params.MemberAsString(param_key.c_str(), &value_string));
                 THROW_IF_BACKEND_MODEL_ERROR(
-                    ParseBoolValue(value_string, &config_.enable_tensorrt_oss_));
+                    ParseBoolValue(value_string, &tensorrt_oss_enabled));
+                if(tensorrt_oss_enabled) {
+                  PD_ConfigEnableVarseqlen(pd_config);
+                }
               } else if (param_key == "is_dynamic") {
                 THROW_IF_BACKEND_MODEL_ERROR(
                     params.MemberAsString(param_key.c_str(), &value_string));
                 THROW_IF_BACKEND_MODEL_ERROR(
-                    ParseBoolValue(value_string, &config_.is_dynamic_));
+                    ParseBoolValue(value_string, &pd_trt_config_.is_dynamic_));
               } else if (param_key == "disenable_trt_tune") {
                 THROW_IF_BACKEND_MODEL_ERROR(
                     params.MemberAsString(param_key.c_str(), &value_string));
                 THROW_IF_BACKEND_MODEL_ERROR(
-                    ParseBoolValue(value_string, &config_.disenable_trt_tune_));
-              } else {
+                    ParseBoolValue(value_string, &pd_trt_config_.disenable_trt_tune_));
+              } else if (param_key == "disable_trt_plugin_fp16") {
+                bool tmp_value;
+                THROW_IF_BACKEND_MODEL_ERROR(
+                    params.MemberAsString(param_key.c_str(), &value_string));
+                THROW_IF_BACKEND_MODEL_ERROR(
+                    ParseBoolValue(value_string, &tmp_value));
+                disable_trt_plugin_fp16 = (PD_Bool)tmp_value;
+              } 
+              else {
                 TRITONSERVER_Error* error = TRITONSERVER_ErrorNew(
                     TRITONSERVER_ERROR_INVALID_ARG,
                     std::string(
@@ -649,26 +303,67 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
               }
             }
           }
+          PD_ConfigEnableTensorRtEngine(pd_config, workspace_size, max_batch_size,
+                                        min_subgraph_size, precision, use_static,
+                                        use_calib_mode);
         } else if (
             name == "min_shape" or name == "max_shape" or name == "opt_shape") {
           triton::common::TritonJson::Value params;
           if (ea.Find("parameters", &params)) {
             std::vector<std::string> input_names;
             THROW_IF_BACKEND_MODEL_ERROR(params.Members(&input_names));
+            if(names_num != 0) {
+              if (names_num != input_names.size()) {
+                throw BackendModelException(TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string(
+                    "The number of min_shape and max_shape are different," +
+                    name + " num:" + std::to_string(names_num) + 
+                    " vs " + std::to_string(input_names.size()))
+                      .c_str())));
+              }
+            } else {
+              names_num = input_names.size();
+              input_tensor_names = new char*[names_num];
+              for (size_t index = 0u; index < names_num; ++index) {
+                input_tensor_names[index] = new char[input_names[index].size() + 1];
+                memcpy(input_tensor_names[index],
+                       input_names[index].c_str(),
+                       input_names[index].size() + 1);
+              }
+              shapes_num = new size_t[names_num];
+              min_shapes = new int32_t*[names_num];
+              max_shapes = new int32_t*[names_num];
+              opt_shapes = new int32_t*[names_num];
+            }
+            size_t index = 0;
             for (const auto& input_name : input_names) {
               std::string str_shape;
               THROW_IF_BACKEND_MODEL_ERROR(
                   params.MemberAsString(input_name.c_str(), &str_shape));
+              std::vector<int32_t> shapes =  
+                    TRITONPADDLE_Shape(str_shape).CompatibleShape();
               if (name == "min_shape") {
-                config_.dynamic_min_shape_[input_name] =
-                    TRITONPADDLE_Shape(str_shape).CompatibleShape();
+                shapes_num[index] = shapes.size();
+                min_shapes[index] = new int32_t[shapes.size()];
+                for (size_t ishape = 0; ishape < shapes.size(); ++ishape) {    \
+                  min_shapes[index][ishape] = shapes[index];                       \
+                }
+                pd_trt_config_.min_shapes_[input_name] = shapes;
               } else if (name == "max_shape") {
-                config_.dynamic_max_shape_[input_name] =
-                    TRITONPADDLE_Shape(str_shape).CompatibleShape();
+                max_shapes[index] = new int32_t[shapes.size()];
+                for (size_t ishape = 0; ishape < shapes.size(); ++ishape) {    \
+                  max_shapes[index][ishape] = shapes[index];                       \
+                }
+                pd_trt_config_.max_shapes_[input_name] = shapes;
               } else {
-                config_.dynamic_opt_shape_[input_name] =
-                    TRITONPADDLE_Shape(str_shape).CompatibleShape();
+                opt_shapes[index] = new int32_t[shapes.size()];
+                for (size_t ishape = 0; ishape < shapes.size(); ++ishape) {    \
+                  opt_shapes[index][ishape] = shapes[index];                       \
+                }
+                pd_trt_config_.opt_shapes_[input_name] = shapes;            
               }
+              index += 1;
             }
           }
         } else {
@@ -682,80 +377,454 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
           THROW_IF_BACKEND_MODEL_ERROR(error);
         }
       }
+      if(names_num > 0) {
+        PD_ConfigSetTrtDynamicShapeInfo(pd_config, names_num, 
+                                        const_cast<const char**>(input_tensor_names),
+                                        shapes_num, min_shapes, max_shapes, opt_shapes,
+                                        disable_trt_plugin_fp16);
+      }
+      delete[] input_tensor_names;
+      delete shapes_num;
+      delete[] min_shapes;
+      delete[] max_shapes;
+      delete[] opt_shapes;
     }
   }
 }
 
 TRITONSERVER_Error*
+ModelState::PrintModelConfig() {
+  // We have the json DOM for the model configuration...
+  common::TritonJson::WriteBuffer buffer;
+  RETURN_IF_ERROR(ModelConfig().PrettyWrite(&buffer));
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_INFO,
+      (std::string("model configuration:\n") + buffer.Contents()).c_str());
+
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error* ModelState::CollectShapeRun(PD_Predictor* predictor,
+                                const std::unordered_map<std::string, std::vector<int>>& shape) {
+  PaddleTensorInfoMap input_tensor_infos;
+  RETURN_IF_ERROR(InputInfos(predictor, input_tensor_infos));
+  std::vector<PD_Tensor*> input_tensors;
+  for(auto& t : input_tensor_infos) {
+    auto& name = t.first;
+    auto& input_info = t.second;
+    RETURN_ERROR_IF_TRUE(
+      shape.find(name) == shape.end(),
+      TRITONSERVER_ERROR_UNAVAILABLE,
+      std::string("Paddle Input name [") + name +
+        "] is not one of the trt dynamic_shape");
+
+    PD_Tensor* pd_tensor = PD_PredictorGetInputHandle(predictor, name.c_str());
+    input_tensors.push_back(pd_tensor);
+    auto shape_value = shape.at(name);
+    int shape_num = std::accumulate(shape_value.begin(), shape_value.end(), 1,
+                                    std::multiplies<int>());
+    PD_TensorReshape(pd_tensor, shape_value.size(), shape_value.data());
+    switch (input_info.type_) {
+      case  PD_DATA_FLOAT32: {
+        std::vector<float> input_data(shape_num, 1.0);
+        PD_TensorCopyFromCpuFloat(pd_tensor, input_data.data());
+        break;
+      }
+      case PD_DATA_INT32: {
+        std::vector<int> input_data(shape_num, 1);
+        PD_TensorCopyFromCpuInt32(pd_tensor, input_data.data());
+        break;
+      }
+      case PD_DATA_INT64: {
+        std::vector<int64_t> input_data(shape_num, 1);
+        PD_TensorCopyFromCpuInt64(pd_tensor, input_data.data());
+        break;
+      }
+      case PD_DATA_INT8: {
+        std::vector<int8_t> input_data(shape_num, 1);
+        PD_TensorCopyFromCpuInt8(pd_tensor, input_data.data());
+        break;
+      }
+      case PD_DATA_UINT8: {
+        std::vector<uint8_t> input_data(shape_num, 1);
+        PD_TensorCopyFromCpuUint8(pd_tensor, input_data.data());
+        break;
+      }
+      default: {
+        RETURN_ERROR_IF_TRUE(
+          true,
+          TRITONSERVER_ERROR_UNAVAILABLE,
+          std::string("input data Paddle backend only supports FP32/INT32/INT64/INT8?UINT8 currently"));
+        break;
+      }
+    }
+  }
+  PD_PredictorRun(predictor);
+  for(auto& pd_tensor : input_tensors){
+    PD_TensorDestroy(pd_tensor);
+  }
+  input_tensors.clear();
+  return nullptr;
+}
+
+TRITONSERVER_Error*
+ModelState::CollectTensorRtShapeRange(std::string* model_path, std::string* params_path,
+                                      const char* range_info_path, int32_t device_id) {
+  PD_Config* pd_config = PD_ConfigCreate();
+  PD_ConfigSetModel(pd_config,
+                    model_path->c_str(),
+                    params_path->c_str());
+  PD_ConfigCollectShapeRangeInfo(pd_config, range_info_path);
+  PD_Predictor* predictor = PD_PredictorCreate(pd_config);
+  RETURN_IF_ERROR(CollectShapeRun(predictor, pd_trt_config_.min_shapes_));
+  RETURN_IF_ERROR(CollectShapeRun(predictor, pd_trt_config_.max_shapes_));
+  RETURN_IF_ERROR(CollectShapeRun(predictor, pd_trt_config_.opt_shapes_));
+  PD_ConfigDestroy(pd_config); 
+  PD_PredictorDestroy(predictor);
+  return nullptr;
+}
+
+TRITONSERVER_Error* ModelState::LoadModel(
+    const std::string& artifact_name,
+    const TRITONSERVER_InstanceGroupKind instance_group_kind,
+    const int32_t instance_group_device_id, std::string* model_path,
+    std::string* params_path, cudaStream_t stream,
+    PD_PlaceType* pd_place_type, PD_Predictor** predictor) {
+  
+  // Paddle Backend creation is not thread-safe, so multiple creations
+  // are serialized with a global lock.
+  // The Clone interface can be invoked only when the main_runtime_ is created.
+  static std::mutex global_context_mu;
+  std::lock_guard<std::mutex> glock(global_context_mu);
+
+  auto dir_path = JoinPath({RepositoryPath(), std::to_string(Version())});
+
+  if (!artifact_name.empty()) {
+    *model_path = JoinPath({dir_path, artifact_name});
+  } else {
+    *model_path = JoinPath({dir_path, "model.pdmodel"});
+    *params_path = JoinPath({dir_path, "model.pdiparams"});
+  }
+
+  // If the model path is a directory then the actual model is
+  // <dir>/model.pdmodel.
+  {
+    bool is_dir;
+    RETURN_IF_ERROR(IsDirectory(*model_path, &is_dir));
+    if (is_dir) {
+      *model_path = JoinPath({*model_path, "model.pdmodel"});
+      *params_path = JoinPath({*params_path, "model.pdiparams"});
+    }
+  }
+
+  {
+    bool exists;
+    RETURN_IF_ERROR(FileExists(*model_path, &exists));
+    RETURN_ERROR_IF_FALSE(
+          exists, TRITONSERVER_ERROR_UNAVAILABLE,
+          std::string("unable to find model: '") + *model_path +
+              "' for model instance '" + Name() + "'");
+    
+    RETURN_IF_ERROR(FileExists(*params_path, &exists));
+    RETURN_ERROR_IF_FALSE(
+          exists, TRITONSERVER_ERROR_UNAVAILABLE,
+          std::string("unable to find params: '") + *params_path +
+              "' for model instance '" + Name() + "'");
+  
+    PD_ConfigSetModel(pd_config_.get(),
+                      model_path->c_str(),
+                      params_path->c_str());
+  }
+
+// GPU
+#ifdef TRITON_ENABLE_GPU
+  if ((instance_group_kind == TRITONSERVER_INSTANCEGROUPKIND_GPU) ||
+      (instance_group_kind == TRITONSERVER_INSTANCEGROUPKIND_AUTO)) {
+    // PD_PRECISION_HALF
+    *pd_place_type = PD_PLACE_GPU;
+    PD_ConfigEnableUseGpu(pd_config_.get(), 100,
+                          instance_group_device_id,
+                          PD_PRECISION_FLOAT32);
+    PD_ConfigSetExecStream(pd_config_.get(), (void*)stream);
+    if(PD_ConfigTensorRtDynamicShapeEnabled(pd_config_.get()) == 1) {
+      auto range_info_path = triton::backend::JoinPath({dir_path, "shape_range_info.pbtxt"});
+      if (!pd_trt_config_.disenable_trt_tune_) {
+          CollectTensorRtShapeRange(model_path, params_path,
+                                    range_info_path.c_str(), instance_group_device_id);
+        }
+        PD_ConfigEnableTunedTensorRtDynamicShape(pd_config_.get(),
+                                                 range_info_path.c_str(), 1);
+    }
+  } else {
+    *pd_place_type = PD_PLACE_CPU;
+    PD_ConfigDisableGpu(pd_config_.get());
+  }
+#else
+  *pd_place_type = PD_PLACE_CPU;
+  PD_ConfigDisableGpu(pd_config_.get());
+#endif  // TRITON_ENABLE_GPU
+  PD_ConfigSwitchIrOptim(pd_config_.get(), 1);
+  PD_ConfigEnableMemoryOptim(pd_config_.get(), 1);
+
+  *predictor = PD_PredictorCreate(pd_config_.get());
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error*
 ModelState::AutoCompleteConfig()
 {
-  // Auto-complete configuration if requests
-  LOG_MESSAGE(
-      TRITONSERVER_LOG_WARN,
-      (std::string("skipping model configuration auto-complete for '") +
-       Name() + "': not supported for paddle backend")
-          .c_str());
+  // If the model configuration already specifies inputs and outputs
+  // then don't perform any auto-completion.
+  size_t input_cnt = 0;
+  size_t output_cnt = 0;
+  {
+    triton::common::TritonJson::Value inputs;
+    if (ModelConfig().Find("input", &inputs)) {
+      input_cnt = inputs.ArraySize();
+    }
+
+    triton::common::TritonJson::Value config_batch_inputs;
+    if (ModelConfig().Find("batch_input", &config_batch_inputs)) {
+      input_cnt += config_batch_inputs.ArraySize();
+    }
+
+    triton::common::TritonJson::Value outputs;
+    if (ModelConfig().Find("output", &outputs)) {
+      output_cnt = outputs.ArraySize();
+    }
+  }
+
+  if ((input_cnt > 0) && (output_cnt > 0)) {
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
+        (std::string("skipping model configuration auto-complete for '") +
+         Name() + "': inputs and outputs already specified")
+            .c_str());
+    return nullptr;  // success
+  }
+
+  std::string artifact_name;
+  RETURN_IF_ERROR(
+      ModelConfig().MemberAsString("default_model_filename", &artifact_name));
+
+  std::unique_ptr<PD_Predictor, PD_PredictorDeleter> pd_predictor;
+  {
+    TRITONSERVER_InstanceGroupKind kind = TRITONSERVER_INSTANCEGROUPKIND_CPU;
+
+#ifdef TRITON_ENABLE_GPU
+    triton::common::TritonJson::Value instance_group;
+    ModelConfig().Find("instance_group", &instance_group);
+
+    // Earlier in the model lifecycle, device checks for the instance group
+    // have already occurred. If at least one instance group with
+    // "kind" = "KIND_GPU" then allow model to use GPU else autocomplete to
+    // "KIND_CPU"
+    for (size_t i = 0; i < instance_group.ArraySize(); ++i) {
+      triton::common::TritonJson::Value instance_obj;
+      RETURN_IF_ERROR(instance_group.IndexAsObject(i, &instance_obj));
+
+      triton::common::TritonJson::Value instance_group_kind;
+      instance_obj.Find("kind", &instance_group_kind);
+      std::string kind_str;
+      RETURN_IF_ERROR(instance_group_kind.AsString(&kind_str));
+
+      if (kind_str == "KIND_GPU") {
+        kind = TRITONSERVER_INSTANCEGROUPKIND_GPU;
+        break;
+      }
+    }
+#endif  // TRITON_ENABLE_GPU
+
+    PD_Predictor* sptr = nullptr;
+    std::string model_path;
+    std::string params_path;
+    PD_PlaceType pd_place_type;
+    RETURN_IF_ERROR(LoadModel(
+        artifact_name, kind, 0, &model_path, &params_path,
+        nullptr, &pd_place_type, &sptr));
+    pd_predictor.reset(sptr);
+  }
+  PaddleTensorInfoMap input_tensor_infos;
+  RETURN_IF_ERROR(
+      InputInfos(pd_predictor.get(), input_tensor_infos));
+  PaddleTensorInfoMap output_tensor_infos;
+  RETURN_IF_ERROR(
+      OutputInfos(pd_predictor.get(), output_tensor_infos));
+  RETURN_IF_ERROR(
+      AutoCompleteMaxBatch(input_tensor_infos, output_tensor_infos));
+  if (input_cnt == 0) {
+    RETURN_IF_ERROR(AutoCompleteIO("input", input_tensor_infos));
+  }
+  if (output_cnt == 0) {
+    RETURN_IF_ERROR(AutoCompleteIO("output", output_tensor_infos));
+  }
+
+  if (TRITONSERVER_LogIsEnabled(TRITONSERVER_LOG_VERBOSE)) {
+    triton::common::TritonJson::WriteBuffer buffer;
+    RETURN_IF_ERROR(ModelConfig().PrettyWrite(&buffer));
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_INFO,
+        (std::string("post auto-complete:\n") + buffer.Contents()).c_str());
+  }
 
   return nullptr;  // success
 }
 
 TRITONSERVER_Error*
-ModelState::ValidateModelConfig()
-{
-  triton::common::TritonJson::WriteBuffer buffer;
-  RETURN_IF_ERROR(ModelConfig().PrettyWrite(&buffer));
-  LOG_MESSAGE(
-      TRITONSERVER_LOG_VERBOSE,
-      (std::string("model configuration:\n") + buffer.Contents()).c_str());
-
-  triton::common::TritonJson::Value ios;
-  RETURN_IF_ERROR(ModelConfig().MemberAsArray("input", &ios));
-  for (size_t i = 0; i < ios.ArraySize(); i++) {
-    triton::common::TritonJson::Value io;
-    RETURN_IF_ERROR(ios.IndexAsObject(i, &io));
-    std::string io_name;
-    RETURN_IF_ERROR(io.MemberAsString("name", &io_name));
-    // Check datatypes
-    std::string io_dtype;
-    RETURN_IF_ERROR(io.MemberAsString("data_type", &io_dtype));
-    RETURN_ERROR_IF_TRUE(
-        ConvertDataType(io_dtype) ==
-            TRITONPADDLE_DataType::TRITONPADDLE_TYPE_INVALID,
-        TRITONSERVER_ERROR_INVALID_ARG,
-        std::string("unsupported datatype '") + io_dtype + "' for tensor '" +
-            io_name + "' for model '" + Name() + "'");
+ModelState::AutoCompleteMaxBatch(
+    const PaddleTensorInfoMap& input_tensor_infos,
+    const PaddleTensorInfoMap& output_tensor_infos) {
+  // Determine if the model can potentially support batching. All
+  // input and output tensors must have a variable first dimension.
+  bool can_support_batching = true;
+  {
+    for (const auto& io_info : input_tensor_infos) {
+      const auto& dims = io_info.second.dims_;
+      if ((dims.size() == 0) || (dims[0] != -1)) {
+        can_support_batching = false;
+      }
+    }
+    for (const auto& io_info : output_tensor_infos) {
+      const auto& dims = io_info.second.dims_;
+      if ((dims.size() == 0) || (dims[0] != -1)) {
+        can_support_batching = false;
+      }
+    }
   }
-  RETURN_IF_ERROR(ModelConfig().MemberAsArray("output", &ios));
-  for (size_t i = 0; i < ios.ArraySize(); i++) {
-    triton::common::TritonJson::Value io;
-    RETURN_IF_ERROR(ios.IndexAsObject(i, &io));
-    std::string io_name;
-    RETURN_IF_ERROR(io.MemberAsString("name", &io_name));
-    // Check datatypes
-    std::string io_dtype;
-    RETURN_IF_ERROR(io.MemberAsString("data_type", &io_dtype));
-    RETURN_ERROR_IF_TRUE(
-        ConvertDataType(io_dtype) ==
-            TRITONPADDLE_DataType::TRITONPADDLE_TYPE_INVALID,
+
+  // Set max-batch-size to 1 if we have determined that batching is
+  // supported and max-batch-size is not specified. We need to update
+  // the configuration itself as well as the cached value we have already
+  // initialized in the model state.
+  if (can_support_batching) {
+    if (MaxBatchSize() == 0) {
+      int default_max_batch_size = 0;
+      {
+        TRITONBACKEND_Backend* backend;
+        THROW_IF_BACKEND_INSTANCE_ERROR(
+            TRITONBACKEND_ModelBackend(TritonModel(), &backend));
+        void* state;
+        THROW_IF_BACKEND_INSTANCE_ERROR(
+            TRITONBACKEND_BackendState(backend, &state));
+        default_max_batch_size = reinterpret_cast<BackendConfiguration*>(state)
+                                     ->default_max_batch_size_;
+      }
+      int max_batch_size = std::max(default_max_batch_size, 0);
+
+      triton::common::TritonJson::Value mbs_value;
+      ModelConfig().Find("max_batch_size", &mbs_value);
+      mbs_value.SetInt(max_batch_size);
+      SetMaxBatchSize(max_batch_size);
+
+      LOG_MESSAGE(
+          TRITONSERVER_LOG_WARN,
+          (std::string(
+               "autofilled max_batch_size to " +
+               std::to_string(max_batch_size) + " for model '") +
+           Name() +
+           "' since batching is supporrted but no max_batch_size is "
+           "specified "
+           "in model configuration. Must specify max_batch_size to utilize "
+           "autofill with a larger max batch size")
+              .c_str());
+    }
+
+    // Check to see if we need to turn on dynamic batching
+    // since model supports batching
+    if (MaxBatchSize() > 1) {
+      triton::common::TritonJson::Value value;
+      bool found_sequence_batching =
+          ModelConfig().Find("sequence_batching", &value);
+      bool found_dynamic_batching =
+          ModelConfig().Find("dynamic_batching", &value);
+      if (!found_sequence_batching && !found_dynamic_batching) {
+        triton::common::TritonJson::Value dynamic_batching(
+            ModelConfig(), triton::common::TritonJson::ValueType::OBJECT);
+        RETURN_IF_ERROR(
+            ModelConfig().Add("dynamic_batching", std::move(dynamic_batching)));
+      }
+    }
+
+  } else if (MaxBatchSize() != 0) {
+    return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG,
-        std::string("unsupported datatype '") + io_dtype + "' for tensor '" +
-            io_name + "' for model '" + Name() + "'");
+        (std::string("autofill failed for model '") + Name() +
+         "': model does not support batching while non-zero max_batch_size"
+         " is specified")
+            .c_str());
+  }
+
+  return nullptr;  // success
+
+}
+
+TRITONSERVER_Error*
+ModelState::AutoCompleteIO(const char* key, const PaddleTensorInfoMap& io_infos)
+{
+  triton::common::TritonJson::Value existing_ios;
+  bool found_ios = ModelConfig().Find(key, &existing_ios);
+
+  triton::common::TritonJson::Value ios(
+      ModelConfig(), triton::common::TritonJson::ValueType::ARRAY);
+  for (const auto& io_info : io_infos) {
+    triton::common::TritonJson::Value io(
+        ModelConfig(), triton::common::TritonJson::ValueType::OBJECT);
+    RETURN_IF_ERROR(io.AddString("name", io_info.first));
+    RETURN_IF_ERROR(io.AddString(
+        "data_type", PaddleDataTypeToModelConfigDataType(io_info.second.type_)));
+
+    // The model signature supports batching then the first dimension
+    // is -1 and should not appear in the model configuration 'dims'
+    // that we are creating.
+    const auto& io_info_dims = io_info.second.dims_;
+    triton::common::TritonJson::Value dims(
+        ModelConfig(), triton::common::TritonJson::ValueType::ARRAY);
+    for (size_t i = (MaxBatchSize() > 0) ? 1 : 0; i < io_info_dims.size();
+         ++i) {
+      RETURN_IF_ERROR(dims.AppendInt(io_info_dims[i]));
+    }
+
+    // If dims are empty then must use a reshape...
+    if (dims.ArraySize() == 0) {
+      RETURN_IF_ERROR(dims.AppendInt(1));
+      triton::common::TritonJson::Value reshape(
+          ModelConfig(), triton::common::TritonJson::ValueType::OBJECT);
+      triton::common::TritonJson::Value reshape_dims(
+          ModelConfig(), triton::common::TritonJson::ValueType::ARRAY);
+      RETURN_IF_ERROR(reshape.Add("shape", std::move(reshape_dims)));
+      RETURN_IF_ERROR(io.Add("reshape", std::move(reshape)));
+    }
+    RETURN_IF_ERROR(io.Add("dims", std::move(dims)));
+    RETURN_IF_ERROR(ios.Append(std::move(io)));
+  }
+
+  if (found_ios) {
+    existing_ios.Swap(ios);
+  } else {
+    ModelConfig().Add(key, std::move(ios));
   }
 
   return nullptr;  // success
 }
 
+//
+// ModelInstanceState
+//
+// State associated with a model instance. An object of this class is
+// created and associated with each TRITONBACKEND_ModelInstance.
+//
 class ModelInstanceState : public BackendModelInstance {
  public:
   static TRITONSERVER_Error* Create(
       ModelState* model_state,
       TRITONBACKEND_ModelInstance* triton_model_instance,
       ModelInstanceState** state);
-  virtual ~ModelInstanceState() = default;
+  virtual ~ModelInstanceState();
 
   // Get the state of the model that corresponds to this instance.
   ModelState* StateForModel() const { return model_state_; }
 
+  // Execute...
   void ProcessRequests(
       TRITONBACKEND_Request** requests, const uint32_t request_count);
 
@@ -763,30 +832,39 @@ class ModelInstanceState : public BackendModelInstance {
   ModelInstanceState(
       ModelState* model_state,
       TRITONBACKEND_ModelInstance* triton_model_instance);
-
-  TRITONSERVER_Error* DetermineModelAndParamsPath(
-      const std::string& model_dir, std::string* model_path,
-      std::string* param_path);
-
-  void SetInputTensors(
+  void ReleaseRunResources();
+  TRITONSERVER_Error* ValidateInputs(const size_t expected_input_cnt);
+  TRITONSERVER_Error* ValidateOutputs();
+  TRITONSERVER_Error* Run(
+      std::vector<TRITONBACKEND_Response*>* responses,
+      const uint32_t response_count);
+  TRITONSERVER_Error* SetInputTensors(
+      size_t total_batch_size, TRITONBACKEND_Request** requests,
+      const uint32_t request_count,
+      std::vector<TRITONBACKEND_Response*>* responses,
+      BackendInputCollector* collector, bool* cuda_copy);
+  TRITONSERVER_Error* ReadOutputTensors(
       size_t total_batch_size, TRITONBACKEND_Request** requests,
       const uint32_t request_count,
       std::vector<TRITONBACKEND_Response*>* responses);
 
-  void ReadOutputTensors(
-      size_t total_batch_size, const std::vector<std::string>& output_names,
-      TRITONBACKEND_Request** requests, const uint32_t request_count,
-      std::vector<TRITONBACKEND_Response*>* responses);
-
   ModelState* model_state_;
-  TRITONPADDLEModelHandle triton_paddle_model_;
+
+  // The full path to the model file.
+  std::string model_path_;
+  std::string params_path_;
+
+  PD_Predictor* pd_predictor_;
+  PD_PlaceType pd_place_type_;
+  std::unordered_map<std::string, TRITONSERVER_DataType> output_names_;
+  std::unordered_map<std::string, PD_Tensor*> input_tensors_;
+  std::unordered_map<std::string, PD_Tensor*> output_tensors_;
 };
 
 TRITONSERVER_Error*
 ModelInstanceState::Create(
     ModelState* model_state, TRITONBACKEND_ModelInstance* triton_model_instance,
-    ModelInstanceState** state)
-{
+    ModelInstanceState** state) {
   try {
     *state = new ModelInstanceState(model_state, triton_model_instance);
   }
@@ -800,205 +878,222 @@ ModelInstanceState::Create(
   return nullptr;  // success
 }
 
-TRITONSERVER_Error*
-ModelInstanceState::DetermineModelAndParamsPath(
-    const std::string& model_dir, std::string* model_path,
-    std::string* param_path)
-{
-  bool exists;
-  *model_path = JoinPath({model_dir, "model.pdmodel"});
-  RETURN_IF_ERROR(FileExists(*model_path, &exists));
-  if (not exists) {
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_NOT_FOUND,
-        std::string(
-            "Paddle model should be named as 'model.pdmodel'").c_str());
-  }
-
-  *param_path = JoinPath({model_dir, "model.pdiparams"});
-  RETURN_IF_ERROR(FileExists(*param_path, &exists));
-  if (not exists) {
-    LOG_MESSAGE(
-      TRITONSERVER_LOG_INFO,
-      (std::string("Paddle params should be named as 'model.pdiparams' or not provided.").c_str()));
-    *param_path = "";
-  }
-
-  return nullptr;
-}
-
 ModelInstanceState::ModelInstanceState(
     ModelState* model_state, TRITONBACKEND_ModelInstance* triton_model_instance)
     : BackendModelInstance(model_state, triton_model_instance),
-      model_state_(model_state)
-{
-  auto config = model_state->PaddleConfig();
-  auto model_dir = JoinPath(
-      {model_state->RepositoryPath(), std::to_string(model_state->Version())});
-  config->model_dir_ = model_dir;
+      model_state_(model_state), pd_predictor_(nullptr),
+      pd_place_type_(PD_PLACE_CPU), output_names_({}),
+      input_tensors_({}), output_tensors_({}) {
+  THROW_IF_BACKEND_INSTANCE_ERROR(model_state->LoadModel(
+      ArtifactFilename(), Kind(), DeviceId(), &model_path_, &params_path_,
+      CudaStream(), &pd_place_type_, &pd_predictor_));
 
-  std::string model_path;
-  std::string param_path;
-  THROW_IF_BACKEND_INSTANCE_ERROR(
-      DetermineModelAndParamsPath(model_dir, &model_path, &param_path));
+  size_t expected_input_cnt = 0;
+  {
+    triton::common::TritonJson::Value inputs;
+    if (model_state->ModelConfig().Find("input", &inputs)) {
+      expected_input_cnt = inputs.ArraySize();
+    }
 
-  switch (Kind()) {
-    case TRITONSERVER_INSTANCEGROUPKIND_CPU:
-      config->use_cpu_ = true;
-      break;
-    case TRITONSERVER_INSTANCEGROUPKIND_GPU:
-      config->use_cpu_ = false;
-      break;
-    default:
-      throw BackendModelInstanceException(TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_INTERNAL,
-          (std::string("unexpected instance kind for ") + name_ +
-           ", paddle_backend only supports CPU/GPU.")
-              .c_str()));
+    triton::common::TritonJson::Value config_batch_inputs;
+    if (model_state->ModelConfig().Find("batch_input", &config_batch_inputs)) {
+      expected_input_cnt += config_batch_inputs.ArraySize();
+    }
   }
 
-  TRITONPADDLE_Model* triton_paddle_model = nullptr;
-  THROW_IF_BACKEND_INSTANCE_ERROR(TRITONPADDLE_ModelCreate(
-      &triton_paddle_model, model_path.c_str(),
-      param_path.empty() ? nullptr : param_path.c_str(),
-      config, DeviceId(), CudaStream()));
-  triton_paddle_model_.reset(triton_paddle_model, TRITONPADDLE_ModelDelete);
+  THROW_IF_BACKEND_INSTANCE_ERROR(ValidateInputs(expected_input_cnt));
+  THROW_IF_BACKEND_INSTANCE_ERROR(ValidateOutputs());
 }
 
-void
-ModelInstanceState::SetInputTensors(
-    size_t total_batch_size, TRITONBACKEND_Request** requests,
-    const uint32_t request_count,
-    std::vector<TRITONBACKEND_Response*>* responses)
+ModelInstanceState::~ModelInstanceState()
 {
-// TRITONSERVER_Error*
-// ModelInstanceState::SetInputTensors(
-//     size_t total_batch_size, TRITONBACKEND_Request** requests,
-//     const uint32_t request_count,
-//     std::vector<TRITONBACKEND_Response*>* responses,
-//     BackendInputCollector* collector, std::vector<const char*>* input_names,
-//     bool* cuda_copy)
-// {
-  bool cuda_copy = false;
-  BackendInputCollector collector(
-      requests, request_count, responses,
-      StateForModel()->TritonMemoryManager(),
-      StateForModel()->EnablePinnedInput(), CudaStream());
-
-  const int max_batch_size = model_state_->MaxBatchSize();
-
-  // All requests must have equally-sized input tensors so use any
-  // request as the representative for the input tensors.
-  uint32_t input_count;
-  RESPOND_ALL_AND_RETURN_IF_ERROR(
-      responses, request_count,
-      TRITONBACKEND_RequestInputCount(requests[0], &input_count));
-
-  for (uint32_t input_idx = 0; input_idx < input_count; ++input_idx) {
-    TRITONBACKEND_Input* input;
-    RESPOND_ALL_AND_RETURN_IF_ERROR(
-        responses, request_count,
-        TRITONBACKEND_RequestInputByIndex(requests[0], input_idx, &input));
-
-    const char* name;
-    TRITONSERVER_DataType datatype;
-    const int64_t* shape;
-    uint32_t dims_count;
-    RESPOND_ALL_AND_RETURN_IF_ERROR(
-        responses, request_count,
-        TRITONBACKEND_InputProperties(
-            input, &name, &datatype, &shape, &dims_count, nullptr, nullptr));
-
-    // The shape for the entire input patch, [total_batch_size, ...]
-    std::vector<int64_t> batchn_shape(shape, shape + dims_count);
-
-    if (max_batch_size != 0) {
-      batchn_shape[0] = total_batch_size;
-    }
-
-    TRITONPADDLE_Tensor* tensor = TRITONPADDLE_TensorNew(
-        triton_paddle_model_.get(), name, ConvertDataType(datatype),
-        TRITONPADDLE_Shape(batchn_shape));
-
-    if (tensor == nullptr) {
-      auto err = TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_INTERNAL,
-          (std::string("Failed to create input tensor '") + name +
-           "' with shape " + backend::ShapeToString(batchn_shape) +
-           " and data type " + TRITONSERVER_DataTypeString(datatype) +
-           " for '" + Name() + "'")
-              .c_str());
-      SendErrorForResponses(responses, request_count, err);
-      return;
-    }
-
-    if (Kind() == TRITONSERVER_INSTANCEGROUPKIND_GPU) {
-      collector.ProcessTensor(
-          name, TRITONPADDLE_TensorData(tensor),
-          TRITONPADDLE_TensorDataByteSize(tensor), TRITONSERVER_MEMORY_GPU,
-          DeviceId());
-    }
-    else {
-        collector.ProcessTensor(
-          name, TRITONPADDLE_TensorData(tensor),
-          TRITONPADDLE_TensorDataByteSize(tensor), TRITONSERVER_MEMORY_CPU,
-          0);
-    }
+  for(auto& t : input_tensors_) {
+    auto& input_tensor = t.second;
+    PD_TensorDestroy(input_tensor);
   }
-
-  cuda_copy |= collector.Finalize();
-  if (cuda_copy) {
-    cudaStreamSynchronize(CudaStream());
+  input_tensors_.clear();
+  
+  for(auto& t : output_tensors_) {
+    auto& output_tensor = t.second;
+    PD_TensorDestroy(output_tensor);
   }
+  output_tensors_.clear();
+
+  PD_PredictorDestroy(pd_predictor_);
 }
 
-void
-ModelInstanceState::ReadOutputTensors(
-    size_t total_batch_size, const std::vector<std::string>& output_names,
-    TRITONBACKEND_Request** requests, const uint32_t request_count,
-    std::vector<TRITONBACKEND_Response*>* responses)
+TRITONSERVER_Error*
+ModelInstanceState::ValidateInputs(const size_t expected_input_cnt)
 {
-  BackendOutputResponder responder(
-      requests, request_count, responses, StateForModel()->MaxBatchSize(),
-      StateForModel()->TritonMemoryManager(),
-      StateForModel()->EnablePinnedOutput(), CudaStream());
+  std::set<std::string> input_tensor_names;
+  {
+    PD_OneDimArrayCstr* c_names = PD_PredictorGetInputNames(pd_predictor_);
+    for(size_t i = 0; i < c_names->size; ++i) {
+      std::string name(c_names->data[i]);
+      input_tensor_names.emplace(std::move(name));
+    }
+    PD_OneDimArrayCstrDestroy(c_names);
+  }
+  PaddleTensorInfoMap input_tensor_infos;
+  RETURN_IF_ERROR(InputInfos(pd_predictor_, input_tensor_infos));
 
-  bool cuda_copy = false;
-  for (size_t idx = 0; idx < output_names.size(); ++idx) {
-    const std::string& name = output_names[idx];
+  if (input_tensor_infos.size() != expected_input_cnt) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        (std::string("unable to load model '") + model_state_->Name() +
+         "', configuration expects " + std::to_string(expected_input_cnt) +
+         " inputs, model provides " + std::to_string(input_tensor_infos.size()))
+            .c_str());
+  }
 
-    TRITONPADDLE_Tensor* tensor =
-        TRITONPADDLE_TensorNew(triton_paddle_model_.get(), name.c_str());
+  triton::common::TritonJson::Value ios;
+  RETURN_IF_ERROR(model_state_->ModelConfig().MemberAsArray("input", &ios));
+  for (size_t i = 0; i < ios.ArraySize(); i++) {
+    triton::common::TritonJson::Value io;
+    RETURN_IF_ERROR(ios.IndexAsObject(i, &io));
+    std::string io_name;
+    RETURN_IF_ERROR(io.MemberAsString("name", &io_name));
+    std::string io_dtype;
+    RETURN_IF_ERROR(io.MemberAsString("data_type", &io_dtype));
 
-    if (tensor == nullptr) {
-      auto err = TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_INTERNAL,
-          (std::string("Failed to create output tensor '") + name + " for '" +
-           Name() + "'")
-              .c_str());
-      SendErrorForResponses(responses, request_count, err);
-      return;
+    auto iit = input_tensor_infos.find(io_name);
+    if (iit == input_tensor_infos.end()) {
+      RETURN_IF_ERROR(CheckAllowedModelInput(io, input_tensor_names));
     }
 
-    auto dtype = ConvertDataType(TRITONPADDLE_TensorDataType(tensor));
-    auto shape = TRITONPADDLE_TensorShape(tensor).Shape();
+    auto pd_data_type = ModelConfigDataTypeToPaddleDataType(io_dtype);
+    if (pd_data_type == PD_DATA_UNK) {
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INTERNAL,
+          (std::string("unsupported datatype ") + io_dtype + " for input '" +
+           io_name + "' for model '" + model_state_->Name() + "'")
+              .c_str());
+    } else if (pd_data_type != iit->second.type_) {
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INVALID_ARG,
+          (std::string("unable to load model '") + model_state_->Name() +
+           "', configuration expects datatype " + io_dtype + " for input '" +
+           io_name + "', model provides TYPE_" +
+           TRITONSERVER_DataTypeString(
+               ConvertFromPaddleDataType(iit->second.type_)))
+              .c_str());
+    }
 
-    if (Kind() == TRITONSERVER_INSTANCEGROUPKIND_GPU) {
-      responder.ProcessTensor(
-          name, dtype, shape, TRITONPADDLE_TensorData(tensor),
-          TRITONSERVER_MEMORY_GPU, DeviceId());
+    // If a reshape is provided for the input then use that when
+    // validating that the model matches what is expected.
+    std::vector<int64_t> dims;
+    triton::common::TritonJson::Value reshape;
+    if (io.Find("reshape", &reshape)) {
+      RETURN_IF_ERROR(ParseShape(reshape, "shape", &dims));
     } else {
-      responder.ProcessTensor(
-          name, dtype, shape, TRITONPADDLE_TensorData(tensor),
-          TRITONSERVER_MEMORY_CPU, 0);
+      RETURN_IF_ERROR(ParseShape(io, "dims", &dims));
     }
+
+    triton::common::TritonJson::Value allow_ragged_batch_json;
+    bool allow_ragged_batch = false;
+    if (io.Find("allow_ragged_batch", &allow_ragged_batch_json)) {
+      RETURN_IF_ERROR(allow_ragged_batch_json.AsBool(&allow_ragged_batch));
+    }
+    if (allow_ragged_batch) {
+      const std::vector<int64_t>& model_shape = iit->second.dims_;
+      // Make sure the input has shpae [-1]
+      if ((model_shape.size() != 1) || (model_shape[0] != WILDCARD_DIM)) {
+        return TRITONSERVER_ErrorNew(
+            TRITONSERVER_ERROR_INVALID_ARG,
+            (std::string("unable to load model '") + model_state_->Name() +
+             "', configuration expects model provides input with shape [-1]  "
+             "for ragged input '" +
+             io_name + "', model provides " + ShapeToString(model_shape))
+                .c_str());
+      }
+    } else {
+      RETURN_IF_ERROR(CompareDimsSupported(
+          model_state_->Name(), io_name, iit->second.dims_, dims,
+          model_state_->MaxBatchSize(), false /* compare_exact */));
+    }
+
+    // Init input tensors
+    PD_Tensor* input_tensor = PD_PredictorGetInputHandle(pd_predictor_, io_name.c_str());
+    input_tensors_.emplace(std::move(io_name), input_tensor);
   }
 
-  cuda_copy |= responder.Finalize();
-  if (cuda_copy) {
-    cudaStreamSynchronize(CudaStream());
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error*
+ModelInstanceState::ValidateOutputs()
+{
+  std::set<std::string> output_tensor_names;
+  {
+    PD_OneDimArrayCstr* c_names = PD_PredictorGetInputNames(pd_predictor_);
+    for(size_t i = 0; i < c_names->size; ++i) {
+      std::string name(c_names->data[i]);
+      output_tensor_names.emplace(std::move(name));
+    }
+    PD_OneDimArrayCstrDestroy(c_names);
   }
 
+  PaddleTensorInfoMap output_tensor_infos;
+  RETURN_IF_ERROR(InputInfos(pd_predictor_, output_tensor_infos));
+
+  triton::common::TritonJson::Value ios;
+  RETURN_IF_ERROR(model_state_->ModelConfig().MemberAsArray("output", &ios));
+  for (size_t i = 0; i < ios.ArraySize(); i++) {
+    triton::common::TritonJson::Value io;
+    RETURN_IF_ERROR(ios.IndexAsObject(i, &io));
+    std::string io_name;
+    RETURN_IF_ERROR(io.MemberAsString("name", &io_name));
+    std::string io_dtype;
+    RETURN_IF_ERROR(io.MemberAsString("data_type", &io_dtype));
+
+    auto iit = output_tensor_infos.find(io_name);
+    if (iit == output_tensor_infos.end()) {
+      RETURN_IF_ERROR(CheckAllowedModelOutput(io, output_tensor_names));
+    }
+
+    auto pd_data_type = ModelConfigDataTypeToPaddleDataType(io_dtype);
+    if (pd_data_type == PD_DATA_UNK) {
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INTERNAL,
+          (std::string("unsupported datatype ") + io_dtype + " for output '" +
+           io_name + "' for model '" + model_state_->Name() + "'")
+              .c_str());
+    } else if (pd_data_type != iit->second.type_) {
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INVALID_ARG,
+          (std::string("unable to load model '") + model_state_->Name() +
+           "', configuration expects datatype " + io_dtype + " for output '" +
+           io_name + "', model provides TYPE_" +
+           TRITONSERVER_DataTypeString(
+               ConvertFromPaddleDataType(iit->second.type_)))
+              .c_str());
+    }
+
+    // If a reshape is provided for the input then use that when
+    // validating that the model matches what is expected.
+    std::vector<int64_t> dims;
+    triton::common::TritonJson::Value reshape;
+    if (io.Find("reshape", &reshape)) {
+      RETURN_IF_ERROR(ParseShape(reshape, "shape", &dims));
+    } else {
+      RETURN_IF_ERROR(ParseShape(io, "dims", &dims));
+    }
+
+    // The batch output shape doesn't necessarily match the model
+    if (model_state_->FindBatchOutput(io_name) == nullptr) {
+      RETURN_IF_ERROR(CompareDimsSupported(
+          model_state_->Name(), io_name, iit->second.dims_, dims,
+          model_state_->MaxBatchSize(), true /* compare_exact */));
+    }
+
+    // Init output tensors
+    output_names_.emplace(std::move(io_name),
+                  TRITONSERVER_StringToDataType(io_dtype.c_str()));
+    PD_Tensor* output_tensor = PD_PredictorGetInputHandle(pd_predictor_, io_name.c_str());
+    output_tensors_.emplace(std::move(io_name), output_tensor);
+  }
+
+  return nullptr;  // success
 }
 
 void
@@ -1020,7 +1115,7 @@ ModelInstanceState::ProcessRequests(
   // execution. The batch-size, number of inputs, and size of each
   // input has already been checked so don't need to do that here.
   size_t total_batch_size = 0;
-  for (size_t i = 0; i < request_count; ++i) {
+  for (size_t i = 0; i < request_count; i++) {
     // If we get a nullptr request then something is badly wrong. Fail
     // and release all requests.
     if (requests[i] == nullptr) {
@@ -1029,7 +1124,8 @@ ModelInstanceState::ProcessRequests(
           TRITONSERVER_ErrorNew(
               TRITONSERVER_ERROR_INTERNAL,
               std::string(
-                  "null request given to Paddle backend for '" + Name() + "'")
+                  "null request given to Paddle backend for '" + Name() +
+                  "'")
                   .c_str()));
       return;
     }
@@ -1055,9 +1151,7 @@ ModelInstanceState::ProcessRequests(
     }
   }
 
-  // If there are no valid requests then no need to run the
-  // inference. This should never happen unless called with an empty
-  // 'requests' for some reason.
+  // If there are no valid payloads then no need to run the inference.
   if (total_batch_size == 0) {
     return;
   }
@@ -1066,9 +1160,8 @@ ModelInstanceState::ProcessRequests(
   // total_batch_size must be 1 for models that don't support batching
   // (i.e. max_batch_size == 0). If max_batch_size is exceeded then
   // scheduler has done something badly wrong so fail and release all
-  // requests
-  if ((total_batch_size != 1) and
-      (total_batch_size > static_cast<size_t>(max_batch_size))) {
+  // requests.
+  if ((total_batch_size != 1) && (total_batch_size > (size_t)max_batch_size)) {
     RequestsRespondWithError(
         requests, request_count,
         TRITONSERVER_ErrorNew(
@@ -1084,17 +1177,18 @@ ModelInstanceState::ProcessRequests(
   // 'requests'. Create a response for each request. During input
   // processing if there is an error with any request that error will
   // be sent immediately with the corresponding response (and the
-  // response pointer will then be nullptr). The request object
+  // response unique_ptr will then be nullptr). The request object
   // itself will not be released until after all inferencing is done
   // (below) as we may need to access the request object when
   // determine how to process outputs (for example, even if we don't
-  // need the outputs for a request that has an error,  we do need to
+  // need the outputs for a request that has an error, we do need to
   // know the size of those outputs associated with the request so we
   // can skip them in the output tensors).
   std::vector<TRITONBACKEND_Response*> responses;
   responses.reserve(request_count);
+  bool all_response_failed = false;
 
-  for (size_t i = 0; i < request_count; ++i) {
+  for (size_t i = 0; i < request_count; i++) {
     TRITONBACKEND_Response* response;
     auto err = TRITONBACKEND_ResponseNew(&response, requests[i]);
     if (err == nullptr) {
@@ -1106,46 +1200,42 @@ ModelInstanceState::ProcessRequests(
     }
   }
 
-  SetInputTensors(total_batch_size, requests, request_count, &responses);
+  bool cuda_copy = false;
+  BackendInputCollector collector(
+      requests, request_count, &responses, model_state_->TritonMemoryManager(),
+      model_state_->EnablePinnedInput(), CudaStream(), nullptr, nullptr, 0,
+      HostPolicyName().c_str());
+  RESPOND_ALL_AND_SET_TRUE_IF_ERROR(
+      responses, request_count, all_response_failed,
+      SetInputTensors(
+          total_batch_size, requests, request_count, &responses, &collector,
+          &cuda_copy));
 
-  // Collect the names of requested outputs. Do not include outputs
-  // for requests that have already responded with an error.
-  // TODO: understand here
-  std::vector<std::string> required_outputs;
-  std::vector<std::vector<std::string>> request_required_outputs(request_count);
-  for (size_t idx = 0; idx < request_count; ++idx) {
-    const auto& request = requests[idx];
-    auto& response = responses[idx];
-    if (response != nullptr) {
-      uint32_t output_count;
-      RESPOND_AND_SET_NULL_IF_ERROR(
-          &response, TRITONBACKEND_RequestOutputCount(request, &output_count));
-      if (response != nullptr) {
-        for (uint32_t output_idx = 0; output_idx < output_count; ++output_idx) {
-          const char* output_name;
-          RESPOND_AND_SET_NULL_IF_ERROR(
-              &response, TRITONBACKEND_RequestOutputName(
-                             request, output_idx, &output_name));
-
-          if (response != nullptr) {
-            required_outputs.push_back(output_name);
-            request_required_outputs[idx].push_back(output_name);
-          }
-        }
-      }
-    }
+  // Wait for any in-flight input tensor copies to complete.
+#ifdef TRITON_ENABLE_GPU
+  if (cuda_copy) {
+    cudaStreamSynchronize(CudaStream());
   }
+#endif
 
   uint64_t compute_start_ns = 0;
   SET_TIMESTAMP(compute_start_ns);
 
-  TRITONPADDLE_ModelRun(triton_paddle_model_.get());
+  if (!all_response_failed) {
+    RESPOND_ALL_AND_SET_TRUE_IF_ERROR(
+        responses, request_count, all_response_failed,
+        Run(&responses, request_count));
+  }
 
   uint64_t compute_end_ns = 0;
   SET_TIMESTAMP(compute_end_ns);
 
-  ReadOutputTensors(
-      total_batch_size, required_outputs, requests, request_count, &responses);
+  if (!all_response_failed) {
+    RESPOND_ALL_AND_SET_TRUE_IF_ERROR(
+        responses, request_count, all_response_failed,
+        ReadOutputTensors(
+            total_batch_size, requests, request_count, &responses));
+  }
 
   uint64_t exec_end_ns = 0;
   SET_TIMESTAMP(exec_end_ns);
@@ -1159,7 +1249,7 @@ ModelInstanceState::ProcessRequests(
       LOG_IF_ERROR(
           TRITONBACKEND_ResponseSend(
               response, TRITONSERVER_RESPONSE_COMPLETE_FINAL, nullptr),
-          "failed to send Paddle backend response");
+          "failed to send paddle backend response");
     }
   }
 
@@ -1178,19 +1268,172 @@ ModelInstanceState::ProcessRequests(
         "failed releasing request");
   }
 
-  // TODO: Report the entire batch statistics.
-  LOG_IF_ERROR(
-      TRITONBACKEND_ModelInstanceReportBatchStatistics(
-          TritonModelInstance(), total_batch_size, exec_start_ns,
-          compute_start_ns, compute_end_ns, exec_end_ns),
-      "failed reporting batch request statistics");
-
-  LOG_MESSAGE(
-      TRITONSERVER_LOG_VERBOSE,
-      (std::string("TRITONBACKEND_ModelExecute: model ") + Name() +
-       " released " + std::to_string(request_count) + " requests")
-          .c_str());
+  if (!all_response_failed) {
+    // Report the entire batch statistics.
+    LOG_IF_ERROR(
+        TRITONBACKEND_ModelInstanceReportBatchStatistics(
+            TritonModelInstance(), total_batch_size, exec_start_ns,
+            compute_start_ns, compute_end_ns, exec_end_ns),
+        "failed reporting batch request statistics");
+  }
 }
+
+TRITONSERVER_Error*
+ModelInstanceState::SetInputTensors(
+    size_t total_batch_size, TRITONBACKEND_Request** requests,
+    const uint32_t request_count,
+    std::vector<TRITONBACKEND_Response*>* responses,
+    BackendInputCollector* collector, bool* cuda_copy) {
+  const int max_batch_size = model_state_->MaxBatchSize();
+
+  // All requests must have equally-sized input tensors so use any
+  // request as the representative for the input tensors.
+  uint32_t input_count;
+  RETURN_IF_ERROR(TRITONBACKEND_RequestInputCount(requests[0], &input_count));
+
+  TRITONSERVER_MemoryType memory_type;
+  int64_t memory_type_id;
+  if (pd_place_type_ == PD_PLACE_GPU) {
+    memory_type = TRITONSERVER_MEMORY_GPU;
+    memory_type_id = DeviceId();
+  } else {
+    memory_type = TRITONSERVER_MEMORY_CPU;
+    memory_type_id = 0;
+  }
+
+  for (uint32_t input_idx = 0; input_idx < input_count; input_idx++) {
+    TRITONBACKEND_Input* input;
+    RETURN_IF_ERROR(
+        TRITONBACKEND_RequestInputByIndex(requests[0], input_idx, &input));
+
+    const char* input_name;
+    TRITONSERVER_DataType input_datatype;
+    const int64_t* input_shape;
+    uint32_t input_dims_count;
+    RETURN_IF_ERROR(TRITONBACKEND_InputProperties(
+        input, &input_name, &input_datatype, &input_shape, &input_dims_count,
+        nullptr, nullptr));
+
+    std::vector<int64_t> batchn_shape;
+    // For a ragged input tensor, the tensor shape should be
+    // the flatten shape of the whole batch
+    if (StateForModel()->IsInputRagged(input_name)) {
+      batchn_shape = std::vector<int64_t>{0};
+      for (size_t idx = 0; idx < request_count; idx++) {
+        TRITONBACKEND_Input* input;
+        RESPOND_AND_SET_NULL_IF_ERROR(
+            &((*responses)[idx]),
+            TRITONBACKEND_RequestInput(requests[idx], input_name, &input));
+        const int64_t* input_shape;
+        uint32_t input_dims_count;
+        RESPOND_AND_SET_NULL_IF_ERROR(
+            &((*responses)[idx]), TRITONBACKEND_InputProperties(
+                                      input, nullptr, nullptr, &input_shape,
+                                      &input_dims_count, nullptr, nullptr));
+
+        batchn_shape[0] += GetElementCount(input_shape, input_dims_count);
+      }
+    }
+    // The shape for the entire input batch, [total_batch_size, ...]
+    else {
+      batchn_shape =
+          std::vector<int64_t>(input_shape, input_shape + input_dims_count);
+      if (max_batch_size != 0) {
+        batchn_shape[0] = total_batch_size;
+      }
+    }
+
+    int64_t batchn_byte_size = GetByteSize(input_datatype, batchn_shape);
+
+    // The input must be in contiguous CPU memory. Use appropriate
+    // allocator info to bind inputs to the right device. .i.e bind inputs
+    // to GPU if they are being provided on GPU.
+    std::string sname(input_name);
+    PD_Tensor* & pd_tensor = input_tensors_[sname];
+    auto pd_shapes = TRITONPADDLE_Shape(batchn_shape).CompatibleShape();
+    PD_TensorReshape(pd_tensor, pd_shapes.size(), pd_shapes.data());
+    char* input_ptr;
+    RETURN_IF_ERROR(PaddleInputMutableData(
+                      pd_tensor, input_datatype,
+                      pd_place_type_, &input_ptr));
+
+    collector->ProcessTensor(input_name, input_ptr, batchn_byte_size,
+                             memory_type, memory_type_id);
+  }
+
+  // Finalize...
+  *cuda_copy |= collector->Finalize();
+  return nullptr;
+}
+
+TRITONSERVER_Error*
+ModelInstanceState::Run(
+    std::vector<TRITONBACKEND_Response*>* responses,
+    const uint32_t response_count)
+{
+  PD_PredictorRun(pd_predictor_);
+#ifdef TRITON_ENABLE_GPU
+  if (Kind() == TRITONSERVER_INSTANCEGROUPKIND_GPU) {
+    cudaStreamSynchronize(CudaStream());
+  }
+#endif
+  return nullptr;
+}
+
+TRITONSERVER_Error*
+ModelInstanceState::ReadOutputTensors(
+    size_t total_batch_size, TRITONBACKEND_Request** requests,
+    const uint32_t request_count,
+    std::vector<TRITONBACKEND_Response*>* responses)
+{
+  BackendOutputResponder responder(
+      requests, request_count, responses, model_state_->TritonMemoryManager(),
+      model_state_->MaxBatchSize() > 0, model_state_->EnablePinnedInput(),
+      CudaStream());
+
+  // Use to hold string output contents
+  bool cuda_copy = false;
+
+  TRITONSERVER_MemoryType memory_type;
+  int64_t memory_type_id;
+
+  for(auto& t : output_names_) {
+    auto& name = t.first;
+    auto& data_type = t.second;
+    PD_Tensor* & pd_tensor = output_tensors_[name];
+    char* out_ptr;
+    PD_PlaceType out_place_type;
+    std::vector<int64_t> output_shapes;
+    RETURN_IF_ERROR(PaddleOutputData(
+      pd_tensor, data_type, &out_place_type, 
+      output_shapes, &out_ptr));
+    
+    if (out_place_type == PD_PLACE_GPU) {
+      memory_type = TRITONSERVER_MEMORY_GPU;
+      memory_type_id = DeviceId();
+    } else {
+      memory_type = TRITONSERVER_MEMORY_CPU;
+      memory_type_id = 0;
+    }
+
+    responder.ProcessTensor(
+        name, data_type,
+        output_shapes, out_ptr,
+        memory_type, memory_type_id);
+  }
+
+  // Finalize and wait for any pending buffer copies.
+  cuda_copy |= responder.Finalize();
+
+#ifdef TRITON_ENABLE_GPU
+  if (cuda_copy) {
+    cudaStreamSynchronize(stream_);
+  }
+#endif  // TRITON_ENABLE_GPU
+  return nullptr;
+}
+
+////////////////
 
 extern "C" {
 
@@ -1250,6 +1493,36 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
       TRITONSERVER_LOG_INFO,
       (std::string("backend configuration:\n") + buffer).c_str());
 
+  triton::common::TritonJson::Value backend_config;
+  TRITONSERVER_Error* err = nullptr;
+  if (byte_size != 0) {
+    err = backend_config.Parse(buffer, byte_size);
+  }
+  RETURN_IF_ERROR(err);
+
+  std::unique_ptr<BackendConfiguration> lconfig(new BackendConfiguration());
+  triton::common::TritonJson::Value cmdline;
+  if (backend_config.Find("cmdline", &cmdline)) {
+    triton::common::TritonJson::Value value;
+    std::string value_str;
+    if (cmdline.Find("default-max-batch-size", &value)) {
+      RETURN_IF_ERROR(value.AsString(&value_str));
+      int lvalue;
+      RETURN_IF_ERROR(ParseIntValue(value_str, &lvalue));
+      lconfig->default_max_batch_size_ = lvalue;
+    }
+  }
+  RETURN_IF_ERROR(TRITONBACKEND_BackendSetState(
+      backend, reinterpret_cast<void*>(lconfig.get())));
+
+  lconfig.release();
+
+  return nullptr;  // success
+}
+
+TRITONBACKEND_ISPEC TRITONSERVER_Error*
+TRITONBACKEND_Finalize(TRITONBACKEND_Backend* backend)
+{
   return nullptr;  // success
 }
 
@@ -1275,6 +1548,8 @@ TRITONBACKEND_ModelInitialize(TRITONBACKEND_Model* model)
   RETURN_IF_ERROR(ModelState::Create(model, &model_state));
   RETURN_IF_ERROR(
       TRITONBACKEND_ModelSetState(model, reinterpret_cast<void*>(model_state)));
+
+  RETURN_IF_ERROR(model_state->PrintModelConfig());
 
   return nullptr;  // success
 }

--- a/src/paddle_backend_utils.h
+++ b/src/paddle_backend_utils.h
@@ -30,65 +30,13 @@
 #include <cstring>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
-#include "paddle_inference_api.h"
-#include "experimental/phi/common/float16.h"
+#include "pd_inference_api.h"
+#include "triton/backend/backend_common.h"
 #include "triton/core/tritonserver.h"
 
-// namespace triton { namespace backend { namespace paddle {
-
-#define RESPOND_ALL_AND_RETURN_IF_ERROR(RESPONSES, RESPONSES_COUNT, X) \
-  do {                                                                 \
-    TRITONSERVER_Error* raarie_err__ = (X);                            \
-    if (raarie_err__ != nullptr) {                                     \
-      SendErrorForResponses(RESPONSES, RESPONSES_COUNT, raarie_err__); \
-      return;                                                          \
-    }                                                                  \
-  } while (false)
-
-#define RETURN_IF_TRITONPADDLE_ERROR(ERR)                                    \
-  do {                                                                       \
-    TRITONPADDLE_Error* error__ = (ERR);                                     \
-    if (error__ != nullptr) {                                                \
-      auto status =                                                          \
-          TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INTERNAL, error__->msg_); \
-      TRITONPADDLE_ErrorDelete(error__);                                     \
-      return status;                                                         \
-    }                                                                        \
-  } while (false)
-
-#define THROW_IF_TRITONPADDLE_ERROR(X)         \
-  do {                                         \
-    TRITONPADDLE_Error* tie_err__ = (X);       \
-    if (tie_err__ != nullptr) {                \
-      throw TRITONPADDLE_Exception(tie_err__); \
-    }                                          \
-  } while (false)
-
-typedef struct {
-  char* msg_;
-} TRITONPADDLE_Error;
-
-struct TRITONPADDLE_Exception {
-  TRITONPADDLE_Exception(TRITONPADDLE_Error* err) : err_(err) {}
-  TRITONPADDLE_Error* err_;
-};
-
-TRITONPADDLE_Error* TRITONPADDLE_ErrorNew(const std::string& str);
-
-void TRITONPADDLE_ErrorDelete(TRITONPADDLE_Error* error);
-
-// TRITONPADDLE TYPE
-// TODO: Full all possible type?
-typedef enum {
-  TRITONPADDLE_TYPE_FP32,
-  TRITONPADDLE_TYPE_INT64,
-  TRITONPADDLE_TYPE_INT32,
-  TRITONPADDLE_TYPE_UINT8,
-  TRITONPADDLE_TYPE_INT8,
-  TRITONPADDLE_TYPE_FP16,
-  TRITONPADDLE_TYPE_INVALID
-} TRITONPADDLE_DataType;
+namespace triton { namespace backend { namespace paddle {
 
 // TRITONPADDLE SHAPE
 class TRITONPADDLE_Shape {
@@ -99,58 +47,72 @@ class TRITONPADDLE_Shape {
   TRITONPADDLE_Shape(const std::string& str);
   template <typename T>
   TRITONPADDLE_Shape(const std::vector<T>& shape);
-  size_t NumElements() const { return numel_; };
 
   std::vector<int32_t> CompatibleShape() const;
-  std::vector<value_type> Shape() const { return shape_; };
 
  private:
   std::vector<value_type> shape_;
-  size_t numel_;
 };
 
-TRITONPADDLE_DataType ConvertDataType(TRITONSERVER_DataType dtype);
-
-TRITONPADDLE_DataType ConvertDataType(::paddle_infer::DataType dtype);
-
-TRITONPADDLE_DataType ConvertDataType(const std::string& dtype);
-
-TRITONSERVER_DataType ConvertDataType(TRITONPADDLE_DataType dtype);
-
-size_t TRITONPADDLE_DataTypeByteSize(TRITONPADDLE_DataType dtype);
-
-// TRITON PADDLE MODE
-typedef enum {
-  TRITONPADDLE_MODE_FP32,
-  TRITONPADDLE_MODE_FP16,
-  TRITONPADDLE_MODE_INT8,
-} TRITONPADDLE_Precision;
-
-// TRITON PADDLE CONFIG
-class TRITONPADDLE_Config {
- public:
-  TRITONPADDLE_Config();
-  // trt
-  bool use_trt_;
-  int64_t max_batch_size_;
-  int64_t workspace_size_;
-  int64_t min_graph_size_;
-  TRITONPADDLE_Precision precision_;
-  bool is_dynamic_;
-  bool enable_tensorrt_oss_;
-  bool disenable_trt_tune_;
-  // cpu
-  bool use_cpu_;
-  bool use_mkldnn_;
-  bool use_ort_;
-  bool use_mkldnn_int8_;
-  int cpu_math_library_num_threads_;
-  int mkldnn_capacity_;
-  std::string model_dir_;
-
-  std::map<std::string, std::vector<int>> dynamic_min_shape_;
-  std::map<std::string, std::vector<int>> dynamic_max_shape_;
-  std::map<std::string, std::vector<int>> dynamic_opt_shape_;
+struct PaddleTRTConfig {
+  std::unordered_map<std::string, std::vector<int>> min_shapes_;
+  std::unordered_map<std::string, std::vector<int>> max_shapes_;
+  std::unordered_map<std::string, std::vector<int>> opt_shapes_;
+  bool is_dynamic_ = false;
+  bool disenable_trt_tune_ = false;
 };
 
-// }}}
+struct PDConfigDeleter {
+  void operator()(PD_Config* f) {
+    PD_ConfigDestroy(f); 
+  }
+};
+
+struct PD_PredictorDeleter {
+  void operator()(PD_Predictor* f) {
+    PD_PredictorDestroy(f);
+  }
+};
+
+struct PaddleTensorInfo {
+  PaddleTensorInfo(PD_DataType type, std::vector<int64_t> dims)
+      : type_(type), dims_(dims){}
+
+  PD_DataType type_;
+  std::vector<int64_t> dims_;
+};
+
+using PaddleTensorInfoMap = std::unordered_map<std::string, PaddleTensorInfo>;
+
+TRITONSERVER_Error*
+InputOutputInfos(PD_Predictor* predictor, bool is_input,
+                 PaddleTensorInfoMap& infos);
+TRITONSERVER_Error* InputInfos(
+    PD_Predictor* predictor, PaddleTensorInfoMap& infos);
+TRITONSERVER_Error* OutputInfos(
+    PD_Predictor* predictor, PaddleTensorInfoMap& infos);
+
+TRITONSERVER_Error* PaddleInputMutableData(
+    PD_Tensor* input_tensor, TRITONSERVER_DataType data_type,
+    PD_PlaceType place_type, char** data_ptr);
+
+TRITONSERVER_Error* PaddleOutputData(
+    PD_Tensor* output_tensor, TRITONSERVER_DataType data_type,
+    PD_PlaceType* place_type, std::vector<int64_t>& shapes,
+    char** data_ptr);
+
+PD_DataType ModelConfigDataTypeToPaddleDataType(
+    const std::string& data_type_str);
+
+std::string PaddleDataTypeToModelConfigDataType(
+    PD_DataType data_type);
+
+TRITONSERVER_DataType
+ConvertFromPaddleDataType(PD_DataType pd_type);
+
+TRITONSERVER_Error* CompareDimsSupported(
+    const std::string& model_name, const std::string& tensor_name,
+    const std::vector<int64_t>& model_shape, const std::vector<int64_t>& dims,
+    const int max_batch_size, const bool compare_exact);
+
+}}}

--- a/src/paddle_backend_utils.h
+++ b/src/paddle_backend_utils.h
@@ -59,7 +59,7 @@ struct PaddleTRTConfig {
   std::unordered_map<std::string, std::vector<int>> max_shapes_;
   std::unordered_map<std::string, std::vector<int>> opt_shapes_;
   bool is_dynamic_ = false;
-  bool disenable_trt_tune_ = false;
+  bool disable_trt_tune_ = false;
 };
 
 struct PDConfigDeleter {


### PR DESCRIPTION
Done:
1. Use PaddlePaddle C API
2. Use the same namespace `triton::backend::paddle`
3. Support the config auto-complete feature and ValidateModelConfig(ValidateOutputs、ValidateInputs)
4. Triton versions are supported from 21.10 to 22.x

Undone (Next PR):
1. add new PaddlePaddle tests
2. add generation scripts for simple PaddlePaddle models
3. add Triton build script (build.py) 
4. Modify README and add some docs to guide users
